### PR TITLE
7440: Explicitly set the Content-Type for the body of POST request in the requester

### DIFF
--- a/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
+++ b/zap/src/main/java/org/parosproxy/paros/network/HttpMessage.java
@@ -990,6 +990,11 @@ public class HttpMessage implements Message {
             if (prevMethod.equalsIgnoreCase(method)) {
                 return;
             }
+            // When changing methods, remove the content-type if a method should not have a body
+            // This does not prevent the user for modifying the request afterwards if needed
+            if (!(method.equals(HttpRequestHeader.POST) || method.equals(HttpRequestHeader.PUT))) {
+                getRequestHeader().setHeader(HttpRequestHeader.CONTENT_TYPE, null);
+            }
             if (prevMethod.equals(HttpRequestHeader.POST)) {
                 // Was POST, move all params onto the URL
                 if (body != null && body.length() > 0) {
@@ -1035,6 +1040,11 @@ public class HttpMessage implements Message {
                             sb.append('=');
                         }
                     }
+                    // Explicitly set the Content-Type for the body of the POST
+                    getRequestHeader()
+                            .setHeader(
+                                    HttpRequestHeader.CONTENT_TYPE,
+                                    HttpRequestHeader.FORM_URLENCODED_CONTENT_TYPE);
                     body = sb.toString();
                     uri.setQuery(null);
                 }

--- a/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
+++ b/zap/src/test/java/org/parosproxy/paros/network/HttpMessageUnitTest.java
@@ -274,6 +274,45 @@ class HttpMessageUnitTest {
     }
 
     @Test
+    void shouldSetContentTypeWhenSettingMethodToPOST() throws Exception {
+        // Given
+        HttpMessage message =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                "GET "
+                                        + "http://www.example.com:9000/?param=param1 HTTP/1.1\r\nHost: www.example.com:9000"));
+        // When
+        message.mutateHttpMethod(HttpRequestHeader.POST);
+        // Then
+        assertThat(message.getRequestHeader().getMethod(), is(HttpRequestHeader.POST));
+        assertThat(
+                message.getRequestHeader().getURI().toString(), is("http://www.example.com:9000/"));
+        assertThat(
+                message.getRequestHeader().getHeader(HttpRequestHeader.CONTENT_TYPE),
+                is(HttpRequestHeader.FORM_URLENCODED_CONTENT_TYPE));
+    }
+
+    @Test
+    void shouldRemoveContentTypeWhenSettingMethodToGET() throws Exception {
+        // Given
+        HttpMessage message =
+                new HttpMessage(
+                        new HttpRequestHeader(
+                                "POST "
+                                        + "http://www.example.com:9000/ HTTP/1.1\r\nHost: www.example.com:9000"));
+        message.setRequestBody("param=param1");
+        // When
+        message.mutateHttpMethod(HttpRequestHeader.GET);
+        // Then
+        assertThat(message.getRequestHeader().getMethod(), is(HttpRequestHeader.GET));
+        assertThat(
+                message.getRequestHeader().getURI().toString(),
+                is("http://www.example.com:9000/?param=param1"));
+        assertThat(
+                message.getRequestHeader().getHeader(HttpRequestHeader.CONTENT_TYPE), nullValue());
+    }
+
+    @Test
     void shouldSetContentEncodingsWhenSettingRequestBodyByte() {
         // Given
         HttpRequestHeader header = mock(HttpRequestHeader.class);


### PR DESCRIPTION
Opening a GET request with the request editor and switching the method with the dropdown from GET to POST moves the query parameters to the request body but it is not adding the correct content-type header, making the call silently fail.
This PR sets correctly the content-type header when switching methods in the requester add-on.

Refer to #7440

Signed-off-by: Leyart <leyart@gmail.com>
